### PR TITLE
ses-test: reenable indirect eval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1706,13 +1706,21 @@
       "dev": true
     },
     "ses": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/ses/-/ses-0.5.1.tgz",
-      "integrity": "sha512-lcifZRRsDBFxnQLsrDufl8/Xd5qcaPEOamVtKmLl898rYjTQRUh+V41hC3Y6B4XFOYFD7ESYtTtit+Ky2cVMTg==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ses/-/ses-0.5.3.tgz",
+      "integrity": "sha512-SoDPdw0XeWgQ7ghM1YrU4GT1u4slTnjvhus+LoT6oAq8y5/kJLTA1oBk2g12/wEwGEWFooMOoYZqUqUh9bFa7Q==",
       "dev": true,
       "requires": {
-        "@agoric/make-hardener": "^0.0.4",
-        "esm": "^3.2.5"
+        "@agoric/make-hardener": "^0.0.6",
+        "esm": "^3.2.25"
+      },
+      "dependencies": {
+        "@agoric/make-hardener": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/@agoric/make-hardener/-/make-hardener-0.0.6.tgz",
+          "integrity": "sha512-OpZcNx/7bhHar0iuQ6D+FKYCMMxqKvYs4aC/bB5v/ffZaSM5sNAl98DnGL1mD9NSyZLGzAZ7D5XwJpe37BMldQ==",
+          "dev": true
+        }
       }
     },
     "shebang-command": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prettier": "^1.16.4",
     "rollup": "^1.16.6",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "ses": "^0.5.1",
+    "ses": "^0.5.3",
     "tap-spec": "^5.0.0",
     "tape": "^4.9.2",
     "tape-promise": "^4.0.0"

--- a/test/ses-test.js
+++ b/test/ses-test.js
@@ -34,10 +34,7 @@ test('infix bang is disabled by default', t => {
       SyntaxError,
       `infix bang fails`,
     );
-    if (false) {
-      // FIXME: (1 , eval) is not a function.
-      t.equals(s.evaluate('(1,eval)("123")'), 123, `indirect eval works`);
-    }
+    t.equals(s.evaluate('(1,eval)("123")'), 123, `indirect eval works`);
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -154,29 +151,15 @@ test('infix bang can be enabled', async t => {
         ),
       );
 
-      let indirEval = noReject;
-      if (true) {
-        // FIXME: Should be noReject.
-        indirEval = fn =>
-          t.rejects(
-            fn(),
-            /\(1 , eval\) is not a function/,
-            `${name} indirect eval fails (FIXME)`,
-          );
-      }
-      await indirEval(async () =>
-        t.equals(
-          await s.evaluate(`(1,eval)('"abc"!length')`),
-          3,
-          `${name} indirect eval works`,
-        ),
+      t.equals(
+        await s.evaluate(`(1,eval)('"abc"!length')`),
+        3,
+        `${name} indirect eval works`,
       );
-      await indirEval(async () =>
-        t.equals(
-          await s.evaluate(`(1,eval)('(1,eval)(\\'"abc"!length\\')')`),
-          3,
-          `${name} nested indirect eval works`,
-        ),
+      t.equals(
+        await s.evaluate(`(1,eval)('(1,eval)(\\'"abc"!length\\')')`),
+        3,
+        `${name} nested indirect eval works`,
       );
     }
   } catch (e) {


### PR DESCRIPTION
SES v0.5.3 has indirect eval support, so use it.