### PR TITLE
package.json: roll back .dev0 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/transform-eventual-send",
-  "version": "1.0.4-dev.0",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/transform-eventual-send",
-  "version": "1.0.4-dev.0",
+  "version": "1.0.3",
   "description": "transform-eventual-send",
   "main": "dist/transform-eventual-send.cjs.js",
   "module": "dist/transform-eventual-send.esm.js",


### PR DESCRIPTION
This prepares for a monorepo, where we want the
packages/transform-eventual-send sub-package to provide `1.0.3` (not
`1.0.4-dev.0`), to be compatible with e.g.
packages/default-evaluate-options (which declares a dependency upon `~1.0.3`,
which is not satisfied by `1.0.4-dev.0`).